### PR TITLE
find correct libraries on FreeBSD

### DIFF
--- a/nimLUA/lua.nim
+++ b/nimLUA/lua.nim
@@ -25,6 +25,9 @@ elif not defined(useLuaJIT):
   when defined(MACOSX):
     const
       LIB_NAME* = "liblua53.dylib"
+  elif defined(FREEBSD):
+    const
+      LIB_NAME* = "liblua-5.3.so"
   elif defined(UNIX):
     const
       LIB_NAME* = "liblua53.so"
@@ -35,6 +38,9 @@ else:
   when defined(MACOSX):
     const
       LIB_NAME* = "libluajit.dylib"
+  elif defined(FREEBSD):
+    const
+      LIB_NAME* = "libluajit-5.1.so"
   elif defined(UNIX):
     const
       LIB_NAME* = "libluajit.so"

--- a/scripts/build.nims
+++ b/scripts/build.nims
@@ -17,6 +17,8 @@ else:
 
 when defined(MACOSX):
   const LIB_NAME* = "liblua5.3.dylib"
+elif defined(FREEBSD):
+  const LIB_NAME* = "liblua-5.3.so"
 elif defined(UNIX):
   const LIB_NAME* = "liblua5.3.so"
 else:


### PR DESCRIPTION
Hello,

thank you for creating this wrapper.
I know you can override the name for the shared library, but to make this wrapper work out of the box on FreeBSD I made some small changes. Now it does so on FreeBSD 12.1

If there is something wrong with my changes, please let me know and I will try to fix them.